### PR TITLE
Drop legacy matlab support

### DIFF
--- a/compile_msound_linux.m
+++ b/compile_msound_linux.m
@@ -77,11 +77,6 @@ end
 eval( [ 'mex', szOptions, szDefines, szPaths, szFiles, szLibs ] );
 
 
-% Call msound to see it doesn't crash... ;-)
-% msound
-
-
-
 function szCmd = addFile  ( szCmd, szFile )
     szCmd = sprintf( '%s "%s"'  , szCmd, szFile );
 function szCmd = addPath  ( szCmd, szPath )

--- a/compile_msound_linux.m
+++ b/compile_msound_linux.m
@@ -1,13 +1,5 @@
 function compile_msound_linux
 
-% The more recent versions of MATLAB (Version 7.3.0.267 (R2006b) and later)
-% use a slightly modified external interfaces API, which is not compatible
-% with older MATLAB versions. If the following flag evaluates true, msound
-% will be compiled using the old API. So it may possibly work with an older
-% MATLAB version. But when it comes to MEX-Files different MATLAB versions
-% may not always be compatible.
-bOldMexApi = false;
-
 % Msound uses the open source library PortAudio which supports various
 % operating systems and audio APIs. For Linux systems the default audio
 % API is Open Sound System (OSS) API. OSS is the default configuration of
@@ -25,12 +17,8 @@ bAlsa = true;
 
 % Another commonly used audio interface is Jack Audio Connection Kit (JACK)
 % API. Using JACK requires the libjack-dev packages to be installed and
-% the following flag to evaluate true. But JACK didn't work at all on the
-% author's test system (ACER eMachines EL1600, Ubuntu Karmic Koala, Matlab
-% 7.5 (R2007b.) Someone with more expertise would possibly be able to get
-% it working.
+% the following flag to evaluate true.
 bJack = false;
-
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 disp('Building msound ...')
@@ -43,16 +31,6 @@ szFiles   = '';
 szLibs    = '';
 
 szOptions = sprintf( '%s %s', szOptions, '-output msound' );
-
-% Use the old MATLAB C API on newer MATLAB versions.
-if( ~verLessThan('matlab','7.3') )
-    if( bOldMexApi )
-        % Use backward compatible old MATLAB C API
-        szOptions = sprintf( '%s %s', szOptions, '-compatibleArrayDims' );
-    else
-        szOptions = sprintf( '%s %s', szOptions, '-largeArrayDims'      );
-    end
-end
 
 % Add main file.
 szFiles = addFile( szFiles, 'msound.c' );

--- a/compile_msound_mac.m
+++ b/compile_msound_mac.m
@@ -1,11 +1,9 @@
 function compile_msound_mac
 
 % Msound uses the open source library PortAudio which supports various
-% operating systems and audio APIs. For Mac systems the default audio
-% API is CoreAudio. CoreAudio is the default configuration of msound,
-% wich should compile on almost any MATLAB system using the installed
-% GCC compiler.
-bCoreAudio = true;
+% operating systems and audio APIs. Mac OS X is completely build around a
+% single audio API which is Core Audio. Therefore no selection of APIs
+% exists for the Mac.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 disp('Building msound ...')
@@ -42,28 +40,22 @@ szFiles = addFile( szFiles, 'portaudio/src/os/unix/pa_unix_hostapis.c' );
 szFiles = addFile( szFiles, 'portaudio/src/os/unix/pa_unix_util.c'     );
 
 % Add PortAudio path for: CoreAudio
-if( bCoreAudio )
-    disp('    Using ''CoreAudio'' ...')
-    % Required defines to compile with CoreAudio support.
-    szDefines = addDefine( szDefines, 'PA_USE_COREAUDIO' );
-    % Trick the compiler into accepting the portaudio source code
-    szDefines = addDefine( szDefines, 'char16_t=UINT16_T');
-    % PortAudio
-    szPaths = addPath( szPaths, 'portaudio/src/hostapi/coreaudio'                 );
-    szFiles = addFile( szFiles, 'portaudio/src/hostapi/coreaudio/pa_mac_core_utilities.c' );
-    szFiles = addFile( szFiles, 'portaudio/src/hostapi/coreaudio/pa_mac_core_blocking.c' );
-    szFiles = addFile( szFiles, 'portaudio/src/hostapi/coreaudio/pa_mac_core.c' );
-    % Libs
-    szOptions = sprintf('%s %s', szOptions, 'LDFLAGS=''\$LDFLAGS -framework CoreFoundation -framework CoreServices -framework CoreAudio -framework AudioToolBox -framework AudioUnit''');
-end
+disp('    Using ''CoreAudio'' ...')
+% Required defines to compile with CoreAudio support.
+szDefines = addDefine( szDefines, 'PA_USE_COREAUDIO' );
+% Trick the compiler into accepting the portaudio source code
+szDefines = addDefine( szDefines, 'char16_t=UINT16_T');
+% PortAudio
+szPaths = addPath( szPaths, 'portaudio/src/hostapi/coreaudio'                 );
+szFiles = addFile( szFiles, 'portaudio/src/hostapi/coreaudio/pa_mac_core_utilities.c' );
+szFiles = addFile( szFiles, 'portaudio/src/hostapi/coreaudio/pa_mac_core_blocking.c' );
+szFiles = addFile( szFiles, 'portaudio/src/hostapi/coreaudio/pa_mac_core.c' );
+% Libs
+szOptions = sprintf('%s %s', szOptions, 'LDFLAGS=''\$LDFLAGS -framework CoreFoundation -framework CoreServices -framework CoreAudio -framework AudioToolBox -framework AudioUnit''');
+
 
 % Build msound MEX-file using default compiler.
 eval( [ 'mex', szOptions, szDefines, szPaths, szFiles, szLibs ] );
-
-
-% Call msound to see it doesn't crash... ;-)
-% msound
-
 
 
 function szCmd = addFile  ( szCmd, szFile )

--- a/compile_msound_mac.m
+++ b/compile_msound_mac.m
@@ -1,13 +1,5 @@
 function compile_msound_mac
 
-% The more recent versions of MATLAB (Version 7.3.0.267 (R2006b) and later)
-% use a slightly modified external interfaces API, which is not compatible
-% with older MATLAB versions. If the following flag evaluates true, msound
-% will be compiled using the old API. So it may possibly work with an older
-% MATLAB version. But when it comes to MEX-Files different MATLAB versions
-% may not always be compatible.
-bOldMexApi = false;
-
 % Msound uses the open source library PortAudio which supports various
 % operating systems and audio APIs. For Mac systems the default audio
 % API is CoreAudio. CoreAudio is the default configuration of msound,
@@ -26,16 +18,6 @@ szFiles   = '';
 szLibs    = '';
 
 szOptions = sprintf( '%s %s', szOptions, '-output msound' );
-
-% Use the old MATLAB C API on newer MATLAB versions.
-if( ~verLessThan('matlab','7.3') )
-    if( bOldMexApi )
-        % Use backward compatible old MATLAB C API
-        szOptions = sprintf( '%s %s', szOptions, '-compatibleArrayDims' );
-    else
-        szOptions = sprintf( '%s %s', szOptions, '-largeArrayDims'      );
-    end
-end
 
 % Add main file.
 szFiles = addFile( szFiles, 'msound.c' );

--- a/compile_msound_win.m
+++ b/compile_msound_win.m
@@ -118,11 +118,6 @@ end
 eval( [ 'mex', szOptions, szDefines, szPaths, szFiles ] );
 
 
-% Call msound to see it doesn't crash... ;-)
-% msound
-
-
-
 function szCmd = addFile  ( szCmd, szFile )
     szCmd = sprintf( '%s %s'  , szCmd, szFile );
 function szCmd = addPath  ( szCmd, szPath )

--- a/compile_msound_win.m
+++ b/compile_msound_win.m
@@ -1,13 +1,5 @@
 function compile_msound_win
 
-% The more recent versions of MATLAB (Version 7.3.0.267 (R2006b) and later)
-% use a slightly modified external interfaces API, which is not compatible
-% with older MATLAB versions. If the following flag evaluates true, msound
-% will be compiled using the old API. So it may possibly work with an older
-% MATLAB version. But when it comes to MEX-Files different MATLAB versions
-% may not always be compatible.
-bOldMexApi = false;
-
 % Msound uses the open source library PortAudio which supports various
 % operating systems and audio APIs. For Windows systems the default audio
 % API is Windows MultiMedia Extensions (WMME). WMME is also the default
@@ -28,7 +20,6 @@ bAsio = false; % Requires ASIO SDK 2.2
 % require you to use the Visual Studio compiler in MEX.
 bWASAPI = false;
 
-
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 disp('Building msound ...')
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -39,16 +30,6 @@ szPaths   = '';
 szFiles   = '';
 
 szOptions = sprintf( '%s %s', szOptions, '-output msound' );
-
-% Use the old MATLAB C API on newer MATLAB versions.
-if( ~verLessThan('matlab','7.3') )
-    if( bOldMexApi )
-        % Use backward compatible old MATLAB C API
-        szOptions = sprintf( '%s %s', szOptions, '-compatibleArrayDims' );
-    else
-        szOptions = sprintf( '%s %s', szOptions, '-largeArrayDims'      );
-    end
-end
 
 % Add main file.
 szFiles = addFile( szFiles, 'msound.c' );


### PR DESCRIPTION
As discussed in #11, support for legacy MATLAB (older than R2006b) is removed from the compile scripts.